### PR TITLE
dynamic falcor model path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ const falcorPostman = require('falcor-postman');
 
 const app = express();
 
-const options = { middlewarePath: '/falcor-postman', falcorPath: '/model.json', app };
+const options = { middlewarePath: '/falcor-postman', falcorModelPath: '/model.json', app };
 
 app.use(falcorPostman(options));
 ```
@@ -27,7 +27,7 @@ Where **options** is an object with the following properties:
 name|type|description|default
 ---|---|---|---|---
 middlewarePath|_string_|Optional: path used to serve the falcor-postman app|'/falcor-postman'|
-falcorPath|_string_|Optional: falcor model path|'/model.json'|
+falcorModelPath|_string_|Optional: falcor model path|'/model.json'|
 app|_object_|The instance of your Express.js app|app
 
 ## UI

--- a/example/server.js
+++ b/example/server.js
@@ -14,7 +14,7 @@ const falcorModelPath = '/example.json';
 const options = { middlewarePath, falcorModelPath, app };
 
 if (isDevelopment) {
-  webpackServeBundle(app);
+  webpackServeBundle(options);
 } else {
   app.use(falcorPostman(options));
 }

--- a/example/server.js
+++ b/example/server.js
@@ -1,9 +1,10 @@
 /* eslint no-console: off */
 const express = require('express');
 const falcorExpress = require('falcor-express');
+const fs = require('fs');
 const Router = require('falcor-router');
-const falcorPostman = require('./../falcor-postman.js');
 const webpackServeBundle = require('./webpackServeBundle');
+const falcorPostman = require('./../falcor-postman.js');
 
 const app = express();
 const isDevelopment = process.env.NODE_ENV !== 'production';
@@ -16,7 +17,7 @@ const options = { middlewarePath, falcorModelPath, app };
 if (isDevelopment) {
   webpackServeBundle(options);
 } else {
-  app.use(falcorPostman(options));
+  app.use(falcorPostman(options, fs));
 }
 
 app.use(falcorModelPath, falcorExpress.dataSourceRoute(() => {

--- a/example/server.js
+++ b/example/server.js
@@ -8,32 +8,26 @@ const webpackServeBundle = require('./webpackServeBundle');
 const app = express();
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
+const middlewarePath = '/falcor-postman';
+const falcorModelPath = '/example.json';
+
+const options = { middlewarePath, falcorModelPath, app };
+
 if (isDevelopment) {
   webpackServeBundle(app);
 } else {
-  app.use(falcorPostman({
-    // # middlewarePath
-    // Optional: path used to serve the falcor-postman app, default:
-    // middlewarePath: '/falcor-postman',
-
-    // # falcorPath
-    // Optional: falcor model path, default:
-    // falcorPath: '/model.json',
-
-    // Express app
-    app
-  }));
+  app.use(falcorPostman(options));
 }
 
-app.use('/model.json', falcorExpress.dataSourceRoute(() => {
+app.use(falcorModelPath, falcorExpress.dataSourceRoute(() => {
   const router = new Router([
     {
       route: 'metrosById[{integers:ids}]["name"]',
       get(pathSet) {
         const metros = [
-          { id: 4, name: 'San Francisco' },
-          { id: 72, name: 'London' },
-          { id: 201, name: 'Tokio' }
+            { id: 4, name: 'San Francisco' },
+            { id: 72, name: 'London' },
+            { id: 201, name: 'Tokio' }
         ];
 
         const results = [];
@@ -56,4 +50,4 @@ app.use('/model.json', falcorExpress.dataSourceRoute(() => {
 }));
 
 const port = process.env.PORT ? process.env.PORT : 3000;
-app.listen(port, () => console.log(`go to http://127.0.0.1:${port}/falcor-postman`));
+app.listen(port, () => console.log(`go to http://127.0.0.1:${port}${middlewarePath}`));

--- a/example/server.js
+++ b/example/server.js
@@ -1,7 +1,6 @@
 /* eslint no-console: off */
 const express = require('express');
 const falcorExpress = require('falcor-express');
-const fs = require('fs');
 const Router = require('falcor-router');
 const webpackServeBundle = require('./webpackServeBundle');
 const falcorPostman = require('./../falcor-postman.js');
@@ -17,7 +16,7 @@ const options = { middlewarePath, falcorModelPath, app };
 if (isDevelopment) {
   webpackServeBundle(options);
 } else {
-  app.use(falcorPostman(options, fs));
+  app.use(falcorPostman(options));
 }
 
 app.use(falcorModelPath, falcorExpress.dataSourceRoute(() => {

--- a/example/server.js
+++ b/example/server.js
@@ -25,9 +25,9 @@ app.use(falcorModelPath, falcorExpress.dataSourceRoute(() => {
       route: 'metrosById[{integers:ids}]["name"]',
       get(pathSet) {
         const metros = [
-            { id: 4, name: 'San Francisco' },
-            { id: 72, name: 'London' },
-            { id: 201, name: 'Tokio' }
+          { id: 4, name: 'San Francisco' },
+          { id: 72, name: 'London' },
+          { id: 201, name: 'Tokio' }
         ];
 
         const results = [];

--- a/example/webpackServeBundle.js
+++ b/example/webpackServeBundle.js
@@ -1,12 +1,12 @@
-const path = require('path');
 const webpack = require('webpack');
-const webpackMiddleware = require('webpack-dev-middleware');
+const webpackDevMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware = require('webpack-hot-middleware');
 const config = require('./../webpack.config.js');
+const falcorPostman = require('./../falcor-postman.js');
 
 module.exports = (options) => {
   const compiler = webpack(config);
-  const middleware = webpackMiddleware(compiler, {
+  const devMiddleware = webpackDevMiddleware(compiler, {
     publicPath: config.output.publicPath,
     stats: {
       colors: true,
@@ -17,14 +17,9 @@ module.exports = (options) => {
       modules: false
     }
   });
+  const hotMiddleware = webpackHotMiddleware(compiler);
 
-  options.app.use(middleware);
-  options.app.use(webpackHotMiddleware(compiler));
-  options.app.get(options.middlewarePath, (req, res) => {
-    res.status(200);
-    const html = middleware.fileSystem.readFileSync(path.join(__dirname, '/../dist/falcor-postman.html'))
-      .toString()
-      .replace(/{{falcor-model-path}}/g, options.falcorModelPath);
-    res.send(html);
-  });
+  options.app.use(devMiddleware);
+  options.app.use(hotMiddleware);
+  options.app.use(falcorPostman(options, devMiddleware.fileSystem));
 };

--- a/example/webpackServeBundle.js
+++ b/example/webpackServeBundle.js
@@ -1,10 +1,10 @@
 const path = require('path');
-const config = require('./../webpack.config.js');
 const webpack = require('webpack');
 const webpackMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware = require('webpack-hot-middleware');
+const config = require('./../webpack.config.js');
 
-module.exports = (app) => {
+module.exports = (options) => {
   const compiler = webpack(config);
   const middleware = webpackMiddleware(compiler, {
     publicPath: config.output.publicPath,
@@ -18,10 +18,13 @@ module.exports = (app) => {
     }
   });
 
-  app.use(middleware);
-  app.use(webpackHotMiddleware(compiler));
-  app.get('/falcor-postman', (req, res) => {
-    res.write(middleware.fileSystem.readFileSync(path.join(__dirname, '/../dist/falcor-postman.html')));
-    res.end();
+  options.app.use(middleware);
+  options.app.use(webpackHotMiddleware(compiler));
+  options.app.get(options.middlewarePath, (req, res) => {
+    res.status(200);
+    const html = middleware.fileSystem.readFileSync(path.join(__dirname, '/../dist/falcor-postman.html'))
+      .toString()
+      .replace(/{{falcor-model-path}}/g, options.falcorModelPath);
+    res.send(html);
   });
 };

--- a/example/webpackServeBundle.js
+++ b/example/webpackServeBundle.js
@@ -21,7 +21,7 @@ module.exports = (options) => {
 
   options.app.use(devMiddleware);
   options.app.use(hotMiddleware);
-  const optionsWithFileSystem = options;
+  const optionsWithFileSystem = Object.assign({}, options);
   optionsWithFileSystem.fileSystem = devMiddleware.fileSystem;
   options.app.use(falcorPostman(optionsWithFileSystem));
 };

--- a/example/webpackServeBundle.js
+++ b/example/webpackServeBundle.js
@@ -21,5 +21,7 @@ module.exports = (options) => {
 
   options.app.use(devMiddleware);
   options.app.use(hotMiddleware);
-  options.app.use(falcorPostman(options, devMiddleware.fileSystem));
+  const optionsWithFileSystem = options;
+  optionsWithFileSystem.fileSystem = devMiddleware.fileSystem;
+  options.app.use(falcorPostman(optionsWithFileSystem));
 };

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -1,15 +1,14 @@
 const express = require('express');
-const fs = require('fs');
 const path = require('path');
 
-module.exports = ({ middlewarePath = '/falcor-postman', falcorModelPath = '/model.json', app }) => {
+module.exports = ({ middlewarePath = '/falcor-postman', falcorModelPath = '/model.json', app }, fileSystem) => {
   app.use(express.static(path.join(__dirname, '/../dist/'), { redirect: false }));
 
   return (req, res, next) => {
     const regexp = new RegExp(`${middlewarePath}(/.*)?$`);
     if (regexp.test(req.url)) {
       res.status(200);
-      const html = fs.readFileSync(path.join(__dirname, '/../dist/falcor-postman.html'))
+      const html = fileSystem.readFileSync(path.join(__dirname, '/../dist/falcor-postman.html'))
         .toString()
         .replace(/{{falcor-model-path}}/g, falcorModelPath);
       res.send(html);

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
 
-module.exports = ({ middlewarePath = '/falcor-postman', falcorModelPath = '/model.json', app }, fileSystem) => {
+module.exports = ({ middlewarePath = '/falcor-postman', falcorModelPath = '/model.json', app, fileSystem = fs }) => {
   app.use(express.static(path.join(__dirname, '/../dist/'), { redirect: false }));
 
   return (req, res, next) => {

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -1,14 +1,18 @@
 const express = require('express');
+const fs = require('fs');
 const path = require('path');
 
-module.exports = ({ middlewarePath = '/falcor-postman', app }) => {
+module.exports = ({ middlewarePath = '/falcor-postman', falcorModelPath = '/model.json', app }) => {
   app.use(express.static(path.join(__dirname, '/../dist/'), { redirect: false }));
 
   return (req, res, next) => {
     const regexp = new RegExp(`${middlewarePath}(/.*)?$`);
     if (regexp.test(req.url)) {
       res.status(200);
-      res.sendFile(path.join(__dirname, '/../dist/falcor-postman.html'));
+      const html = fs.readFileSync(path.join(__dirname, '/../dist/falcor-postman.html'))
+        .toString()
+        .replace(/{{falcor-model-path}}/g, falcorModelPath);
+      res.send(html);
       return;
     }
     next();

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "rimraf dist && NODE_ENV=production webpack --progress --profile --colors && NODE_ENV=production",
+    "build": "rimraf dist && NODE_ENV=production webpack --progress --profile --colors",
     "coverage": "istanbul cover _mocha -x src/model.js -- --compilers js:babel-register --compilers jsx:babel-register --recursive -r jsdom-global/register",
     "lint": "eslint --ignore-pattern 'coverage/*' --ignore-pattern 'dist/*' . ",
     "production": "npm run build && NODE_ENV=production PORT=3000 node example/server.js",
@@ -43,9 +43,11 @@
     "test"
   ],
   "dependencies": {
+    "express": "^4.14.0",
     "falcor": "^0.1.17",
     "falcor-http-datasource": "^0.1.3",
     "lockr": "^0.8.4",
+    "path": "^0.12.7",
     "react": "^15.3.1",
     "react-codemirror": "^0.2.6",
     "react-dom": "^15.3.1"
@@ -65,7 +67,6 @@
     "eslint-config-opentable": "^6.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^6.6.0",
-    "express": "^4.14.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "falcor-express": "^0.1.2",
     "falcor-router": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "eslint --ignore-pattern 'coverage/*' --ignore-pattern 'dist/*' . ",
     "production": "npm run build && NODE_ENV=production PORT=3000 node example/server.js",
     "start": "PORT=3000 node example/server.js",
-    "test": "npm run build && mocha --compilers js:babel-register --compilers jsx:babel-register --recursive -r jsdom-global/register"
+    "test": "mocha --compilers js:babel-register --compilers jsx:babel-register --recursive -r jsdom-global/register"
   },
   "pre-commit": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "eslint --ignore-pattern 'coverage/*' --ignore-pattern 'dist/*' . ",
     "production": "npm run build && NODE_ENV=production PORT=3000 node example/server.js",
     "start": "PORT=3000 node example/server.js",
-    "test": "mocha --compilers js:babel-register --compilers jsx:babel-register --recursive -r jsdom-global/register"
+    "test": "npm run build && mocha --compilers js:babel-register --compilers jsx:babel-register --recursive -r jsdom-global/register"
   },
   "pre-commit": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falcor-postman",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "A graphical interactive in-browser Falcor queries validator IDE.",
   "main": "falcor-postman.js",
   "author": {

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -41,7 +41,7 @@ export default class App extends React.Component {
   }
 
   falcorGet() {
-    this.props.model(this.props.falcorPath).get(...JSON.parse(this.state.query))
+    this.props.model.get(...JSON.parse(this.state.query))
       .then((response) => {
         if (response) {
           this.setState({ response, error: {} });
@@ -110,10 +110,5 @@ export default class App extends React.Component {
 }
 
 App.propTypes = {
-  model: React.PropTypes.func,
-  falcorPath: React.PropTypes.string
-};
-
-App.defaultProps = {
-  falcorPath: '/model.json'
+  model: React.PropTypes.object
 };

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,9 +4,10 @@ import App from './app.jsx';
 import model from './model';
 import './static/css/styles.scss';
 
+const falcorModelPath = document.getElementById('app').getAttribute('data-falcor-model-path');
+
 const props = {
-  model,
-  falcorPath: '/model.json'
+  model: model(falcorModelPath)
 };
 
 ReactDOM.render(<App {...props} />, document.getElementById('app'));

--- a/src/model.js
+++ b/src/model.js
@@ -1,4 +1,4 @@
 import Falcor from 'falcor';
 import FalcorDataSource from 'falcor-http-datasource';
 
-export default falcorPath => new Falcor.Model({ source: new FalcorDataSource(falcorPath) });
+export default falcorModelPath => new Falcor.Model({ source: new FalcorDataSource(falcorModelPath) });

--- a/src/static/template.html
+++ b/src/static/template.html
@@ -7,6 +7,6 @@
     <meta name="author" content="big-mars Team" />
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app" data-falcor-model-path="{{falcor-model-path}}"></div>
   </body>
 </html>

--- a/test/app/app.spec.jsx
+++ b/test/app/app.spec.jsx
@@ -20,7 +20,7 @@ describe('<App />', () => {
   const then = sinon.stub(); // info: need to find a better way to mock a Promise
   const props = {
     model: () => ({ get: () => ({ then }) }),
-    falcorPath: '/model.json'
+    falcorModelPath: '/model.json'
   };
 
   describe('when rendered', () => {

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -1,3 +1,4 @@
+/* eslint global-require: "off" */
 const chai = require('chai');
 const sinon = require('sinon');
 
@@ -12,8 +13,15 @@ describe('middleware', () => {
       }
     };
 
-    /* eslint global-require: "off" */
-    let middleware = require('./../middleware/')(options);
+    const fileSystem = {
+      readFileSync: () => ({
+        toString: () => ({
+          replace: sinon.spy()
+        })
+      })
+    };
+
+    let middleware = require('./../middleware/')(options, fileSystem);
 
     it('should be a valid middleware function', () => {
       middleware.should.be.instanceof(Function);
@@ -67,7 +75,7 @@ describe('middleware', () => {
           use: sinon.spy()
         }
       };
-      middleware = require('../middleware')(options);
+      middleware = require('../middleware')(options, fileSystem);
 
       middleware(req, res, next);
 

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -26,7 +26,7 @@ describe('middleware', () => {
 
     describe('when invoked and options.middlewarePath doesn\'t match req.url', () => {
       const req = { url: '/' };
-      const res = { status: sinon.stub(), sendFile: sinon.stub() };
+      const res = { status: sinon.stub(), send: sinon.stub() };
       const next = sinon.stub();
 
       middleware(req, res, next);
@@ -38,7 +38,7 @@ describe('middleware', () => {
 
     describe('when invoked at default /falcor-postman (options.middlewarePath not defined) matches req.url', () => {
       const req = { url: '/falcor-postman' };
-      const res = { status: sinon.stub(), sendFile: sinon.stub() };
+      const res = { status: sinon.stub(), send: sinon.stub() };
       const next = sinon.stub();
 
       middleware(req, res, next);
@@ -48,7 +48,7 @@ describe('middleware', () => {
       });
 
       it('should call res.send', () => {
-        sinon.assert.called(res.sendFile);
+        sinon.assert.called(res.send);
       });
 
       it('should not call next', () => {
@@ -58,7 +58,7 @@ describe('middleware', () => {
 
     describe('when invoked at custom defined path /postman matches req.url', () => {
       const req = { url: '/postman' };
-      const res = { status: sinon.stub(), sendFile: sinon.stub() };
+      const res = { status: sinon.stub(), send: sinon.stub() };
       const next = sinon.stub();
 
       options = {
@@ -76,7 +76,7 @@ describe('middleware', () => {
       });
 
       it('should call res.send', () => {
-        sinon.assert.called(res.sendFile);
+        sinon.assert.called(res.send);
       });
 
       it('should not call next', () => {

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -6,13 +6,6 @@ chai.should();
 
 describe('middleware', () => {
   describe('when instantiated', () => {
-    let options = {
-      // middlewarePath: '/falcor-postman',
-      app: {
-        use: sinon.spy()
-      }
-    };
-
     const fileSystem = {
       readFileSync: () => ({
         toString: () => ({
@@ -21,7 +14,15 @@ describe('middleware', () => {
       })
     };
 
-    let middleware = require('./../middleware/')(options, fileSystem);
+    let options = {
+      // middlewarePath: '/falcor-postman',
+      app: {
+        use: sinon.spy()
+      },
+      fileSystem
+    };
+
+    let middleware = require('./../middleware/')(options);
 
     it('should be a valid middleware function', () => {
       middleware.should.be.instanceof(Function);
@@ -73,9 +74,10 @@ describe('middleware', () => {
         middlewarePath: '/postman',
         app: {
           use: sinon.spy()
-        }
+        },
+        fileSystem
       };
-      middleware = require('../middleware')(options, fileSystem);
+      middleware = require('../middleware')(options);
 
       middleware(req, res, next);
 


### PR DESCRIPTION
# Description

w/ this PR we will be able to consume a dynamic Falcor model path and not only `/model.json`. this has been achieved adding a `data-*` attribute at the template level and its content will be set by the middleware at the HTTP request level; the example included is using, for instance, the `/example.json` endpoint

## Outstanding

- [ ] ~~try to use string interpolation instead of serving an HTML~~

- [X] make the test build independent